### PR TITLE
chore(app-android): enable proguard and network security config

### DIFF
--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -1,0 +1,27 @@
+-keep @kotlinx.serialization.Serializable class * {
+    *;
+}
+
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    public static void checkNotNull(...);
+    public static void checkExpressionValueIsNotNull(...);
+    public static void checkNotNullExpressionValue(...);
+    public static void checkParameterIsNotNull(...);
+    public static void checkNotNullParameter(...);
+    public static void checkReturnedValueIsNotNull(...);
+    public static void checkFieldIsNotNull(...);
+    public static void throwUninitializedPropertyAccessException(...);
+    public static void throwNpe(...);
+    public static void throwJavaNpe(...);
+    public static void throwAssert(...);
+    public static void throwIllegalArgument(...);
+    public static void throwIllegalState(...);
+}
+
+-assumenosideeffects class android.util.Log {
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+    public static int w(...);
+    public static int e(...);
+}

--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
         android:fullBackupContent="@null"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:memtagMode="async"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@android:style/Theme.Material.NoActionBar"
         tools:targetApi="31">
 

--- a/app-android/src/main/res/xml/network_security_config.xml
+++ b/app-android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2024 AnyGogin31
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">oauth.secure.pixiv.net</domain>
+        <domain includeSubdomains="true">app-api.pixiv.net</domain>
+    </domain-config>
+</network-security-config>

--- a/build-logic/src/main/java/neilt/mobile/convention/AndroidApplication.kt
+++ b/build-logic/src/main/java/neilt/mobile/convention/AndroidApplication.kt
@@ -60,12 +60,11 @@ internal fun Project.configureAndroidApplication(
 
         buildTypes {
             release {
-                isMinifyEnabled = false
-                isShrinkResources = false
+                isMinifyEnabled = true
+                isShrinkResources = true
                 isCrunchPngs = true
                 isDebuggable = false
                 multiDexEnabled = true
-                renderscriptOptimLevel = 3
 
                 signingConfig = signingConfigs.getByName("release")
 


### PR DESCRIPTION
Enables Proguard for release builds and introduces a network security configuration:

- Adds Proguard rules to keep necessary classes and methods.
- Enables Proguard, resource shrinking, and PNG crunching for release builds.
- Sets `memtagMode` to "async" and adds a network security configuration to enforce HTTPS for specific domains.
- Creates a network security configuration file that disables cleartext traffic for Pixiv API domains.