### PR TITLE
feat(illustration): add illustration download functionality

### DIFF
--- a/data/src/androidMain/kotlin/neilt/mobile/pixiv/data/di/PlatformLocalModule.kt
+++ b/data/src/androidMain/kotlin/neilt/mobile/pixiv/data/di/PlatformLocalModule.kt
@@ -26,7 +26,9 @@ package neilt.mobile.pixiv.data.di
 
 import neilt.mobile.pixiv.data.local.provider.AndroidDatabaseProvider
 import neilt.mobile.pixiv.data.local.provider.DatabaseProvider
+import neilt.mobile.pixiv.data.provider.AndroidStorageProvider
 import neilt.mobile.pixiv.data.provider.AndroidTimeProvider
+import neilt.mobile.pixiv.data.provider.StorageProvider
 import neilt.mobile.pixiv.data.provider.TimeProvider
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -34,5 +36,6 @@ import org.koin.dsl.module
 
 internal actual val platformLocalModule = module {
     singleOf(::AndroidDatabaseProvider) bind DatabaseProvider::class
+    singleOf(::AndroidStorageProvider) bind StorageProvider::class
     singleOf(::AndroidTimeProvider) bind TimeProvider::class
 }

--- a/data/src/commonMain/kotlin/neilt/mobile/pixiv/data/provider/StorageProvider.kt
+++ b/data/src/commonMain/kotlin/neilt/mobile/pixiv/data/provider/StorageProvider.kt
@@ -22,31 +22,8 @@
  * SOFTWARE.
  */
 
-package neilt.mobile.pixiv.data.remote.services.details.illustration
+package neilt.mobile.pixiv.data.provider
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.url
-import io.ktor.http.URLBuilder
-import neilt.mobile.pixiv.data.remote.common.AUTHORIZATION_REQUIRED_HEADER
-import neilt.mobile.pixiv.data.remote.responses.details.illustration.IllustrationDetailsRootResponse
-
-class IllustrationService(private val client: HttpClient) {
-    suspend fun fetchIllustration(illustrationId: Int): IllustrationDetailsRootResponse {
-        return client.get("/v1/illust/detail?filter=for_android") {
-            headers.append(AUTHORIZATION_REQUIRED_HEADER, "true")
-            parameter("illust_id", illustrationId)
-        }.body()
-    }
-
-    suspend fun downloadIllustration(url: String): ByteArray {
-        return client.get(url) {
-            headers.append("Referer", "https://www.pixiv.net")
-            url.takeIf { it.startsWith("http") }?.let {
-                this.url(URLBuilder(it).build())
-            }
-        }.body()
-    }
+interface StorageProvider {
+    fun uploadImage(image: ByteArray, fileName: String)
 }

--- a/data/src/commonMain/kotlin/neilt/mobile/pixiv/data/repositories/details/illustration/IllustrationRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/neilt/mobile/pixiv/data/repositories/details/illustration/IllustrationRepositoryImpl.kt
@@ -25,14 +25,21 @@
 package neilt.mobile.pixiv.data.repositories.details.illustration
 
 import neilt.mobile.pixiv.data.mapper.details.illustration.toModel
+import neilt.mobile.pixiv.data.provider.StorageProvider
 import neilt.mobile.pixiv.data.remote.services.details.illustration.IllustrationService
 import neilt.mobile.pixiv.domain.models.details.illustration.IllustrationDetails
 import neilt.mobile.pixiv.domain.repositories.details.illustration.IllustrationRepository
 
 class IllustrationRepositoryImpl(
     private val illustrationService: IllustrationService,
+    private val storageProvider: StorageProvider,
 ) : IllustrationRepository {
     override suspend fun getIllustration(illustrationId: Int): IllustrationDetails {
         return illustrationService.fetchIllustration(illustrationId).illustrationDetails.toModel()
+    }
+
+    override suspend fun downloadIllustration(url: String, fileName: String) {
+        val imageData = illustrationService.downloadIllustration(url)
+        storageProvider.uploadImage(imageData, fileName)
     }
 }

--- a/domain/src/commonMain/kotlin/neilt/mobile/pixiv/domain/repositories/details/illustration/IllustrationRepository.kt
+++ b/domain/src/commonMain/kotlin/neilt/mobile/pixiv/domain/repositories/details/illustration/IllustrationRepository.kt
@@ -28,4 +28,5 @@ import neilt.mobile.pixiv.domain.models.details.illustration.IllustrationDetails
 
 interface IllustrationRepository {
     suspend fun getIllustration(illustrationId: Int): IllustrationDetails
+    suspend fun downloadIllustration(url: String, fileName: String)
 }

--- a/features/illustration/src/androidMain/kotlin/neilt/mobile/pixiv/features/illustration/di/PlatformIllustrationFeatureModule.kt
+++ b/features/illustration/src/androidMain/kotlin/neilt/mobile/pixiv/features/illustration/di/PlatformIllustrationFeatureModule.kt
@@ -22,31 +22,14 @@
  * SOFTWARE.
  */
 
-package neilt.mobile.pixiv.data.remote.services.details.illustration
+package neilt.mobile.pixiv.features.illustration.di
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.url
-import io.ktor.http.URLBuilder
-import neilt.mobile.pixiv.data.remote.common.AUTHORIZATION_REQUIRED_HEADER
-import neilt.mobile.pixiv.data.remote.responses.details.illustration.IllustrationDetailsRootResponse
+import neilt.mobile.pixiv.features.illustration.provider.AndroidToastProvider
+import neilt.mobile.pixiv.features.illustration.provider.ToastProvider
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
 
-class IllustrationService(private val client: HttpClient) {
-    suspend fun fetchIllustration(illustrationId: Int): IllustrationDetailsRootResponse {
-        return client.get("/v1/illust/detail?filter=for_android") {
-            headers.append(AUTHORIZATION_REQUIRED_HEADER, "true")
-            parameter("illust_id", illustrationId)
-        }.body()
-    }
-
-    suspend fun downloadIllustration(url: String): ByteArray {
-        return client.get(url) {
-            headers.append("Referer", "https://www.pixiv.net")
-            url.takeIf { it.startsWith("http") }?.let {
-                this.url(URLBuilder(it).build())
-            }
-        }.body()
-    }
+internal actual val platformIllustrationFeatureModule = module {
+    singleOf(::AndroidToastProvider) bind ToastProvider::class
 }

--- a/features/illustration/src/androidMain/kotlin/neilt/mobile/pixiv/features/illustration/provider/AndroidToastProvider.kt
+++ b/features/illustration/src/androidMain/kotlin/neilt/mobile/pixiv/features/illustration/provider/AndroidToastProvider.kt
@@ -22,31 +22,13 @@
  * SOFTWARE.
  */
 
-package neilt.mobile.pixiv.data.remote.services.details.illustration
+package neilt.mobile.pixiv.features.illustration.provider
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.url
-import io.ktor.http.URLBuilder
-import neilt.mobile.pixiv.data.remote.common.AUTHORIZATION_REQUIRED_HEADER
-import neilt.mobile.pixiv.data.remote.responses.details.illustration.IllustrationDetailsRootResponse
+import android.content.Context
+import android.widget.Toast
 
-class IllustrationService(private val client: HttpClient) {
-    suspend fun fetchIllustration(illustrationId: Int): IllustrationDetailsRootResponse {
-        return client.get("/v1/illust/detail?filter=for_android") {
-            headers.append(AUTHORIZATION_REQUIRED_HEADER, "true")
-            parameter("illust_id", illustrationId)
-        }.body()
-    }
-
-    suspend fun downloadIllustration(url: String): ByteArray {
-        return client.get(url) {
-            headers.append("Referer", "https://www.pixiv.net")
-            url.takeIf { it.startsWith("http") }?.let {
-                this.url(URLBuilder(it).build())
-            }
-        }.body()
+class AndroidToastProvider(private val context: Context) : ToastProvider {
+    override fun showToast(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     }
 }

--- a/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/di/IllustrationFeatureModule.kt
+++ b/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/di/IllustrationFeatureModule.kt
@@ -25,9 +25,14 @@
 package neilt.mobile.pixiv.features.illustration.di
 
 import neilt.mobile.pixiv.features.illustration.presentation.details.IllustrationDetailsViewModel
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val illustrationFeatureModule = module {
     viewModelOf(::IllustrationDetailsViewModel)
+
+    includes(platformIllustrationFeatureModule)
 }
+
+internal expect val platformIllustrationFeatureModule: Module

--- a/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/presentation/details/IllustrationDetailsView.kt
+++ b/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/presentation/details/IllustrationDetailsView.kt
@@ -24,7 +24,9 @@
 
 package neilt.mobile.pixiv.features.illustration.presentation.details
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -79,13 +81,22 @@ internal fun IllustrationDetailsView(
         state.whenState<IllustrationDetails>(
             onLoading = { LoadingView() },
             onError = { ErrorView(message = it) },
-            onLoaded = { IllustrationDetailsContent(illustration = it) },
+            onLoaded = {
+                IllustrationDetailsContent(
+                    illustration = it,
+                    onIllustrationDownload = viewModel::downloadIllustration,
+                )
+            },
         )
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun IllustrationDetailsContent(illustration: IllustrationDetails) {
+private fun IllustrationDetailsContent(
+    illustration: IllustrationDetails,
+    onIllustrationDownload: (url: String?, fileName: String) -> Unit,
+) {
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
@@ -96,7 +107,16 @@ private fun IllustrationDetailsContent(illustration: IllustrationDetails) {
             contentDescription = illustration.title,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surface),
+                .background(MaterialTheme.colorScheme.surface)
+                .combinedClickable(
+                    onClick = { },
+                    onLongClick = {
+                        onIllustrationDownload(
+                            illustration.imageUrl.largeUrl,
+                            illustration.title,
+                        )
+                    },
+                ),
             contentScale = ContentScale.Crop,
         )
 

--- a/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/presentation/details/IllustrationDetailsViewModel.kt
+++ b/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/presentation/details/IllustrationDetailsViewModel.kt
@@ -38,9 +38,11 @@ import neilt.mobile.pixiv.core.state.LoadedState
 import neilt.mobile.pixiv.core.state.LoadingState
 import neilt.mobile.pixiv.core.state.ViewState
 import neilt.mobile.pixiv.domain.repositories.details.illustration.IllustrationRepository
+import neilt.mobile.pixiv.features.illustration.provider.ToastProvider
 
 internal class IllustrationDetailsViewModel(
     private val illustrationRepository: IllustrationRepository,
+    private val toastProvider: ToastProvider,
 ) : ViewModel() {
     private val _state = MutableStateFlow<ViewState>(LoadingState)
     val state: StateFlow<ViewState> = _state.asStateFlow()
@@ -58,6 +60,18 @@ internal class IllustrationDetailsViewModel(
                     message = e.message ?: "Error loading illustrations",
                 )
             }
+        }
+    }
+
+    fun downloadIllustration(url: String?, fileName: String) {
+        if (url.isNullOrEmpty()) {
+            return
+        }
+
+        viewModelScope.launch {
+            toastProvider.showToast("Downloading...")
+            illustrationRepository.downloadIllustration(url, fileName)
+            toastProvider.showToast("Download complete")
         }
     }
 }

--- a/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/provider/ToastProvider.kt
+++ b/features/illustration/src/commonMain/kotlin/neilt/mobile/pixiv/features/illustration/provider/ToastProvider.kt
@@ -22,31 +22,8 @@
  * SOFTWARE.
  */
 
-package neilt.mobile.pixiv.data.remote.services.details.illustration
+package neilt.mobile.pixiv.features.illustration.provider
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.url
-import io.ktor.http.URLBuilder
-import neilt.mobile.pixiv.data.remote.common.AUTHORIZATION_REQUIRED_HEADER
-import neilt.mobile.pixiv.data.remote.responses.details.illustration.IllustrationDetailsRootResponse
-
-class IllustrationService(private val client: HttpClient) {
-    suspend fun fetchIllustration(illustrationId: Int): IllustrationDetailsRootResponse {
-        return client.get("/v1/illust/detail?filter=for_android") {
-            headers.append(AUTHORIZATION_REQUIRED_HEADER, "true")
-            parameter("illust_id", illustrationId)
-        }.body()
-    }
-
-    suspend fun downloadIllustration(url: String): ByteArray {
-        return client.get(url) {
-            headers.append("Referer", "https://www.pixiv.net")
-            url.takeIf { it.startsWith("http") }?.let {
-                this.url(URLBuilder(it).build())
-            }
-        }.body()
-    }
+interface ToastProvider {
+    fun showToast(message: String)
 }

--- a/features/illustration/src/iosMain/kotlin/neilt/mobile/pixiv/features/illustration/di/PlatformIllustrationFeatureModule.kt
+++ b/features/illustration/src/iosMain/kotlin/neilt/mobile/pixiv/features/illustration/di/PlatformIllustrationFeatureModule.kt
@@ -22,31 +22,12 @@
  * SOFTWARE.
  */
 
-package neilt.mobile.pixiv.data.remote.services.details.illustration
+package neilt.mobile.pixiv.features.illustration.di
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.url
-import io.ktor.http.URLBuilder
-import neilt.mobile.pixiv.data.remote.common.AUTHORIZATION_REQUIRED_HEADER
-import neilt.mobile.pixiv.data.remote.responses.details.illustration.IllustrationDetailsRootResponse
+import org.koin.dsl.module
 
-class IllustrationService(private val client: HttpClient) {
-    suspend fun fetchIllustration(illustrationId: Int): IllustrationDetailsRootResponse {
-        return client.get("/v1/illust/detail?filter=for_android") {
-            headers.append(AUTHORIZATION_REQUIRED_HEADER, "true")
-            parameter("illust_id", illustrationId)
-        }.body()
-    }
-
-    suspend fun downloadIllustration(url: String): ByteArray {
-        return client.get(url) {
-            headers.append("Referer", "https://www.pixiv.net")
-            url.takeIf { it.startsWith("http") }?.let {
-                this.url(URLBuilder(it).build())
-            }
-        }.body()
-    }
+internal actual val platformIllustrationFeatureModule = module {
+    throw NotImplementedError(
+        "This function is not implemented for the current platform. Platform-specific implementation required.",
+    )
 }


### PR DESCRIPTION
Adds the ability to download illustrations and save them to the device's storage.

- Introduces a `ToastProvider` to display download status messages.
- Adds a `downloadIllustration` function to the `IllustrationRepository` and its implementation.
- Adds a `downloadIllustration` function to the `IllustrationDetailsViewModel` to handle download requests.
- Modifies the `IllustrationDetailsContent` composable to trigger the download on long press.
- Updates the `IllustrationService` to include a `downloadIllustration` function for fetching image data.
- Introduces a `StorageProvider` for saving the downloaded image to the device's storage.
- Adds platform-specific implementations for `ToastProvider` and `StorageProvider` for Android.
- Includes platform-specific modules for dependency injection.